### PR TITLE
Check map before registering test.

### DIFF
--- a/registration.go
+++ b/registration.go
@@ -36,6 +36,9 @@ func RegisterTest(t Test) {
 	}
 	t.id = fmt.Sprintf("%x", h.Sum32())
 
+	if _, ok := mainTestSuite[t.Name]; ok {
+		panic("a test of the same name was previously registered: " + t.Name)
+	}
 	mainTestSuite[t.Name] = t
 }
 


### PR DESCRIPTION
This is to avoid accidentally overriding tests that have the same name,  which would result in registered getting lost.
