### PR TITLE
add list command with a tests and suites subcommand

### DIFF
--- a/command.go
+++ b/command.go
@@ -42,7 +42,7 @@ func NewCommand(
 		},
 	}
 
-	var cmdListTests = &cobra.Command{
+	var cmdList = &cobra.Command{
 		Use:           "list",
 		Aliases:       []string{"ls"},
 		Short:         "List registered tests.",
@@ -51,8 +51,17 @@ func NewCommand(
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return viper.BindPFlags(cmd.Flags())
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+	}
 
+	var cmdListTests = &cobra.Command{
+		Use:           "tests",
+		Short:         "List registered tests.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			suites := filterSuites()
 			return listTests(suites)
 		},
@@ -60,6 +69,24 @@ func NewCommand(
 
 	cmdListTests.Flags().StringSliceP("id", "i", nil, "Only run tests with the given identifier")
 	cmdListTests.Flags().StringSliceP("tag", "t", nil, "Only run tests with the given tags")
+
+	var cmdListSuites = &cobra.Command{
+		Use:           "suites",
+		Short:         "List registered suites.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			suites := filterSuites()
+			return listSuites(suites)
+		},
+	}
+
+	cmdListSuites.Flags().StringSliceP("suite", "Z", nil, "Only run suites specified")
+
+	cmdList.AddCommand(cmdListTests, cmdListSuites)
 
 	var cmdRunTests = &cobra.Command{
 		Use:           "test",
@@ -185,7 +212,7 @@ func NewCommand(
 
 	rootCmd.AddCommand(
 		versionCmd,
-		cmdListTests,
+		cmdList,
 		cmdRunTests,
 	)
 

--- a/list.go
+++ b/list.go
@@ -1,9 +1,20 @@
 package apocheck
 
+import "fmt"
+
 func listTests(suites []*suiteInfo) error {
 
 	for _, suite := range suites {
 		suite.listTests()
+	}
+
+	return nil
+}
+
+func listSuites(suites []*suiteInfo) error {
+
+	for _, suite := range suites {
+		fmt.Printf("%s\n", suite)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

created a list command that has 2 subommands, tests and suites, which will print out a list of all tests and suites. These commands also support a few flags to filter out what is printed. This depends on #4 getting merged

## Motivation and Context

Want a way to list all suites/specified suites. 

## How Has This Been Tested?

example cli commands 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Breaking change (fix or feature that would cause existing functionality to change)
listing tests is now moved to list tests, previously it was just lists

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
